### PR TITLE
Fix: Correct parameter naming in OffBoard interface functions

### DIFF
--- a/lib/solidity/MpcInterface.sol
+++ b/lib/solidity/MpcInterface.sol
@@ -5,10 +5,10 @@ interface ExtendedOperations {
 
     function OnBoard(bytes1 metaData, uint256 ct) external returns (uint256 result);
     function OnBoard(bytes1 metaData, uint256 ctHigh, uint256 ctLow) external returns (uint256 result);
-    function OffBoard(bytes1 metaData, uint256 ct) external returns (uint256 result);
+    function OffBoard(bytes1 metaData, uint256 gt) external returns (uint256 result);
     function OffBoard256(bytes1 metaData, uint256 gt) external returns (uint256 ctHigh, uint256 ctLow);
-    function OffBoardToUser(bytes1 metaData, uint256 ct, bytes calldata addr) external returns (uint256 result);
-    function OffBoardToUser256(bytes1 metaData, uint256 ct, bytes calldata addr) external returns (uint256 ctHigh, uint256 ctLow);
+    function OffBoardToUser(bytes1 metaData, uint256 gt, bytes calldata addr) external returns (uint256 result);
+    function OffBoardToUser256(bytes1 metaData, uint256 gt, bytes calldata addr) external returns (uint256 ctHigh, uint256 ctLow);
     function SetPublic(bytes1 metaData, uint256 ct) external returns (uint256 result);
     function Rand(bytes1 metaData) external returns (uint256 result);
     function RandBoundedBits(bytes1 metaData, uint8 numBits) external returns (uint256 result);


### PR DESCRIPTION
### **User description**
## Summary
I noticed what might be a small inconsistency in parameter naming, but **I could be completely wrong** - please let me know if I'm misunderstanding something!

## Observation
While studying the codebase to understand how MPC operations work, I came across the `OffBoard` family of functions. **Correct me if I'm wrong**, but it seems like:

1. These functions take garbled token (gt) values as input
2. They return ciphertext (ct) values as output
3. However, the parameter is currently named `ct` instead of `gt`

I noticed that `OffBoard256` already uses `gt` as the parameter name, which made me wonder if the others should match.

## My Understanding (May Be Incorrect!)
Looking at `MpcCore.sol`, it appears that all the function calls pass `gtType` values:

```solidity
function offBoard(gtUint8 pt) internal returns (ctUint8) {
    return ctUint8.wrap(ExtendedOperations(address(MPC_PRECOMPILE)).
        OffBoard(bytes1(uint8(MPC_TYPE.SUINT8_T)), gtUint8.unwrap(pt)));
        //                                          ^^^^ GT type being passed
}
```

**But again, I might be missing context** about why it's currently named `ct`.

## Note
I'm genuinely uncertain if this is the right change, so **please feel free to close this if it doesn't make sense**! I'm here to learn and contribute positively.

Thank you so much🙏


___

### **PR Type**
Bug fix


___

### **Description**
- Corrects parameter naming in OffBoard interface functions

- Changes input parameter from `ct` to `gt` in three functions

- Aligns with semantic meaning: garbled tokens convert to ciphertext

- Ensures consistency with `OffBoard256` and actual implementation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OffBoard Functions<br/>Parameter: ct"] -->|Rename| B["OffBoard Functions<br/>Parameter: gt"]
  C["OffBoard256<br/>Already uses gt"] -.->|Consistency| B
  D["MpcCore.sol<br/>Passes gtType"] -.->|Alignment| B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MpcInterface.sol</strong><dd><code>Rename OffBoard function parameters from ct to gt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/solidity/MpcInterface.sol

<ul><li>Renamed <code>ct</code> parameter to <code>gt</code> in <code>OffBoard</code> function (line 7)<br> <li> Renamed <code>ct</code> parameter to <code>gt</code> in <code>OffBoardToUser</code> function (line 9)<br> <li> Renamed <code>ct</code> parameter to <code>gt</code> in <code>OffBoardToUser256</code> function (line 10)<br> <li> Maintains consistency with <code>OffBoard256</code> which already uses <code>gt</code> naming</ul>


</details>


  </td>
  <td><a href="https://github.com/soda-mpc/soda-contracts/pull/9/files#diff-a048d208e67c50dd67321aaba34e63ed4d632ebaafe933770e71e31457e14b49">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

