### PR TITLE
CI: skip chain tests for non-code changes, clearer RPC error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,18 @@ name: Test
 on:
   push:
     branches: [ "master" ]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - 'NOTICE'
+      - '.gitignore'
   pull_request:
     branches: [ "master" ]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - 'NOTICE'
+      - '.gitignore'
 
 jobs:
   build:

--- a/lib/python/soda_web3_helper.py
+++ b/lib/python/soda_web3_helper.py
@@ -43,7 +43,12 @@ class SodaWeb3Helper:
         self.web3.eth.default_account = self.account.address
         self.web3.middleware_onion.inject(geth_poa_middleware, layer=0) 
         if not self.web3.is_connected():
-            raise Exception("Failed to connect to the node.")
+            raise ConnectionError(
+                f"Could not reach the Bubble RPC endpoint at {http_provider_url}.\n"
+                "Nothing was wrong with the request: the node did not answer at all.\n"
+                "Check that the host is up and accepting connections on that port "
+                "before looking for a bug in the contracts or the test."
+            )
         print(f'Connected to the node at {http_provider_url}')
 
         self.contracts = {}


### PR DESCRIPTION
## 1. `paths-ignore`

The `Test` workflow runs integration tests against a live node, so a change touching only `LICENSE` or a README fails for reasons that have nothing to do with it. That is what happened on #10.

Chain tests are now skipped when a change touches only `**/*.md`, `LICENSE`, `NOTICE` or `.gitignore`. Everything else still runs the full suite.

## 2. A useful failure message

The suite currently dies with:

```
Exception: Failed to connect to the node.
```

which reads like the code is broken. It now says which endpoint went unanswered and where to look:

```
Could not reach the Bubble RPC endpoint at http://testnet.node.sodalabs.net:7000.
Nothing was wrong with the request: the node did not answer at all.
Check that the host is up and accepting connections on that port before looking
for a bug in the contracts or the test.
```

Also raises `ConnectionError` rather than a bare `Exception`, so callers can catch it.

## Expect this PR itself to fail

It changes the workflow, so `paths-ignore` does not apply to it and the full suite runs. It will fail on the same unreachable node until that host is back:

`http://testnet.node.sodalabs.net:7000` resolves to `52.87.55.29` but accepts no connections. `master` last had a green run on 2025-11-05, so this is a standing infrastructure problem rather than a regression.

Once this is merged, #10 can be rebased and its chain tests will be skipped.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>